### PR TITLE
fix: add right return type on needed function

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Backend/Monitoring&QA

--- a/src/M6Web/Bundle/LogBridgeBundle/Config/FilterCollection.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Config/FilterCollection.php
@@ -145,18 +145,12 @@ class FilterCollection implements \Iterator
         return $this->iterator;
     }
 
-    /**
-     * next
-     */
-    public function next()
+    public function next(): void
     {
         $this->iterator++;
     }
 
-    /**
-     * rewind
-     */
-    public function rewind()
+    public function rewind(): void
     {
         $this->iterator = 0;
     }

--- a/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/Configuration.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/Configuration.php
@@ -15,7 +15,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('m6web_log_bridge');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/M6Web/Bundle/LogBridgeBundle/Logger/Logger.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Logger/Logger.php
@@ -25,72 +25,72 @@ class Logger implements LoggerInterface
     /**
      * {@inheritdoc}
      */
-    public function emergency($message, array $context = [])
+    public function emergency($message, array $context = []): void
     {
-        return $this->logger->emergency($message, $context);
+        $this->logger->emergency($message, $context);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function alert($message, array $context = [])
+    public function alert($message, array $context = []): void
     {
-        return $this->logger->alert($message, $context);
+        $this->logger->alert($message, $context);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function critical($message, array $context = [])
+    public function critical($message, array $context = []): void
     {
-        return $this->logger->critical($message, $context);
+        $this->logger->critical($message, $context);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function error($message, array $context = [])
+    public function error($message, array $context = []): void
     {
-        return $this->logger->error($message, $context);
+        $this->logger->error($message, $context);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function warning($message, array $context = [])
+    public function warning($message, array $context = []): void
     {
-        return $this->logger->warning($message, $context);
+        $this->logger->warning($message, $context);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function notice($message, array $context = [])
+    public function notice($message, array $context = []): void
     {
-        return $this->logger->notice($message, $context);
+        $this->logger->notice($message, $context);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function info($message, array $context = [])
+    public function info($message, array $context = []): void
     {
-        return $this->logger->info($message, $context);
+        $this->logger->info($message, $context);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function debug($message, array $context = [])
+    public function debug($message, array $context = []): void
     {
-        return $this->logger->debug($message, $context);
+        $this->logger->debug($message, $context);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
-        return $this->logger->log($level, $message, $context);
+        $this->logger->log($level, $message, $context);
     }
 }


### PR DESCRIPTION
I have some deprecations notice from phpunit when using this bundle on a PHP 8 project.
This PR aim fix them.

```
1x: Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "M6Web\Bundle\LogBridgeBundle\DependencyInjection\Configuration" now to avoid errors or add an explicit @return annotation to suppress this message.
  1x: Method "Psr\Log\LoggerInterface::emergency()" might add "void" as a native return type declaration in the future. Do the same in implementation "M6Web\Bundle\LogBridgeBundle\Logger\Logger" now to avoid errors or add an explicit @return annotation to suppress this message.
  1x: Method "Psr\Log\LoggerInterface::alert()" might add "void" as a native return type declaration in the future. Do the same in implementation "M6Web\Bundle\LogBridgeBundle\Logger\Logger" now to avoid errors or add an explicit @return annotation to suppress this message.
  1x: Method "Psr\Log\LoggerInterface::critical()" might add "void" as a native return type declaration in the future. Do the same in implementation "M6Web\Bundle\LogBridgeBundle\Logger\Logger" now to avoid errors or add an explicit @return annotation to suppress this message.
  1x: Method "Psr\Log\LoggerInterface::error()" might add "void" as a native return type declaration in the future. Do the same in implementation "M6Web\Bundle\LogBridgeBundle\Logger\Logger" now to avoid errors or add an explicit @return annotation to suppress this message.
  1x: Method "Psr\Log\LoggerInterface::warning()" might add "void" as a native return type declaration in the future. Do the same in implementation "M6Web\Bundle\LogBridgeBundle\Logger\Logger" now to avoid errors or add an explicit @return annotation to suppress this message.
  1x: Method "Psr\Log\LoggerInterface::notice()" might add "void" as a native return type declaration in the future. Do the same in implementation "M6Web\Bundle\LogBridgeBundle\Logger\Logger" now to avoid errors or add an explicit @return annotation to suppress this message.
  1x: Method "Psr\Log\LoggerInterface::info()" might add "void" as a native return type declaration in the future. Do the same in implementation "M6Web\Bundle\LogBridgeBundle\Logger\Logger" now to avoid errors or add an explicit @return annotation to suppress this message.
  1x: Method "Psr\Log\LoggerInterface::debug()" might add "void" as a native return type declaration in the future. Do the same in implementation "M6Web\Bundle\LogBridgeBundle\Logger\Logger" now to avoid errors or add an explicit @return annotation to suppress this message.
  1x: Method "Psr\Log\LoggerInterface::log()" might add "void" as a native return type declaration in the future. Do the same in implementation "M6Web\Bundle\LogBridgeBundle\Logger\Logger" now to avoid errors or add an explicit @return annotation to suppress this message.
  1x: Method "Iterator::next()" might add "void" as a native return type declaration in the future. Do the same in implementation "M6Web\Bundle\LogBridgeBundle\Config\FilterCollection" now to avoid errors or add an explicit @return annotation to suppress this message.
  1x: Method "Iterator::rewind()" might add "void" as a native return type declaration in the future. Do the same in implementation "M6Web\Bundle\LogBridgeBundle\Config\FilterCollection" now to avoid errors or add an explicit @return annotation to suppress this message.
```