### PR TITLE
fix(parser): parser could find route and routes in config

### DIFF
--- a/src/M6Web/Bundle/LogBridgeBundle/Config/FilterParser.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Config/FilterParser.php
@@ -74,7 +74,7 @@ class FilterParser
             throw new ParseException(sprintf('Undefined "route(s)", "method" or "status" parameter from filter "%s"', $name));
         }
 
-        if (array_key_exists('route', $config) && array_key_exists('routes', $config)) {
+        if ((array_key_exists('route', $config) && $config['route'] !== null) && (array_key_exists('routes', $config) && !empty($config['routes']))) {
             throw new ParseException(sprintf('You can\'t use both "route" and "routes" parameter from filter "%s"', $name));
         }
 


### PR DESCRIPTION
# Why

Sometimes the config could find `route` and `routes` in array

# How

Change the test to throw the exception of both `route` and `routes` set

