### PR TITLE
fix(log): avoid duplicated log when there is a subrequest by listening to kernel.terminate

### DIFF
--- a/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/M6WebLogBridgeExtension.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/M6WebLogBridgeExtension.php
@@ -73,7 +73,7 @@ class M6WebLogBridgeExtension extends Extension
             ->addTag(
                 'kernel.event_listener',
                 [
-                    'event' => 'kernel.response',
+                    'event' => 'kernel.terminate',
                     'method' => 'onKernelTerminate',
                 ]
             );

--- a/src/M6Web/Bundle/LogBridgeBundle/EventDispatcher/LogRequestListener.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/EventDispatcher/LogRequestListener.php
@@ -7,7 +7,7 @@ namespace M6Web\Bundle\LogBridgeBundle\EventDispatcher;
 use M6Web\Bundle\LogBridgeBundle\Formatter\FormatterInterface;
 use M6Web\Bundle\LogBridgeBundle\Matcher\MatcherInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
 
 /**
  * LogRequestListener
@@ -22,7 +22,7 @@ class LogRequestListener
     {
     }
 
-    public function onKernelTerminate(ResponseEvent $event): void
+    public function onKernelTerminate(TerminateEvent $event): void
     {
         if ($this->matcher === null) {
             return;


### PR DESCRIPTION
## Description

See #73. We can use `kernel.terminate` since [it is correctly triggered on main requests](https://github.com/symfony/http-kernel/blob/53aa7cf03143f990a47de18157d312d3bd66c11b/Event/TerminateEvent.php#L21-L22).

From my tests, it goes fine for valid requests and for failed requests.

<details><summary>Example log for a valid request</summary>

```
[2022-09-01 10:38:06] log_bridge.INFO: Request ------------------------ host                : 127.0.0.1:8000 user-agent          : Mozilla/5.0 (X11; Linux x86_64; rv:104.0) Gecko/20100101 Firefox/104.0 accept              : text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8 accept-encoding     : gzip, deflate, br accept-language     : fr,en-US;q=0.7,en;q=0.3 dnt                 : 1 sec-fetch-dest      : document sec-fetch-mode      : navigate sec-fetch-site      : none sec-fetch-user      : ?1 te                  : trailers upgrade-insecure-requests: 1 x-forwarded-for     : 127.0.0.1 x-php-ob-level      : 1 ------------------------ Response ------------------------ HTTP 1.1 200 Age:           0 Etag:           Vary:           Cache-Control:      max-age=2, public Content-Type:       text/plain; charset=UTF-8 Date:               Thu, 01 Sep 2022 08:38:06 GMT X-Debug-Token:      413a0d X-Debug-Token-Link: http://127.0.0.1:8000/_profiler/413a0d X-Robots-Tag:       noindex Response body ------------------------ OK  {"project":"*****","environment":"dev","route":"get_status","method":"GET","status":200,"user":"","key":"dev.get_status.GET.200","uri":"http://127.0.0.1:8000/status","request_id":133008276824294,"hostname":"*****"} []
```
</details>

<details><summary>Example log for a failed request</summary>

```
[2022-09-01 10:38:27] log_bridge.CRITICAL: Request ------------------------ host                : 127.0.0.1:8000 user-agent          : Mozilla/5.0 (X11; Linux x86_64; rv:104.0) Gecko/20100101 Firefox/104.0 accept              : text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8 accept-encoding     : gzip, deflate, br accept-language     : fr,en-US;q=0.7,en;q=0.3 dnt                 : 1 sec-fetch-dest      : document sec-fetch-mode      : navigate sec-fetch-site      : none sec-fetch-user      : ?1 te                  : trailers upgrade-insecure-requests: 1 x-forwarded-for     : 127.0.0.1 x-php-ob-level      : 1 ------------------------ Response ------------------------ HTTP 1.1 500 Age:           0 Etag:           Vary:           Cache-Control:          no-cache, private Content-Type:           application/json Date:                   Thu, 01 Sep 2022 08:38:27 GMT X-Debug-Token:          e8fcfe X-Debug-Token-Link:     http://127.0.0.1:8000/_profiler/e8fcfe X-Previous-Debug-Token: a21fd6 X-Robots-Tag:           noindex Response body ------------------------ {     "code": 500,     "message": "oops" }  Exception class :  ------------------------ RuntimeException  Exception message (1) : ------------------------ oops  Exception trace (1) : ------------------------ #0 /*****/*****/*****/*****/vendor/symfony/http-kernel/HttpKernel.php(158): *****\*****\*****\*****\*****->*****() #1 /*****/*****/*****/*****/vendor/symfony/http-kernel/HttpKernel.php(80): Symfony\Component\HttpKernel\HttpKernel->handleRaw() #2 /*****/*****/*****/*****/vendor/symfony/http-kernel/Kernel.php(201): Symfony\Component\HttpKernel\HttpKernel->handle() #3 /*****/*****/*****/*****/public/index.php(40): Symfony\Component\HttpKernel\Kernel->handle() #4 {main}  {"project":"*****","environment":"dev","route":"get_status","method":"GET","status":500,"user":"","key":"dev.get_status.GET.500","uri":"http://127.0.0.1:8000/status","request_id":133028436425592,"hostname":"*****"} []
```
</details>

