### PR TITLE
Backport #74 into v6

### DIFF
--- a/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/M6WebLogBridgeExtension.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/M6WebLogBridgeExtension.php
@@ -76,7 +76,7 @@ class M6WebLogBridgeExtension extends Extension
             ->addTag(
                 'kernel.event_listener',
                 [
-                    'event' => 'kernel.response',
+                    'event' => 'kernel.terminate',
                     'method' => 'onKernelTerminate',
                 ]
             );

--- a/src/M6Web/Bundle/LogBridgeBundle/EventDispatcher/LogRequestListener.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/EventDispatcher/LogRequestListener.php
@@ -5,6 +5,7 @@ namespace M6Web\Bundle\LogBridgeBundle\EventDispatcher;
 use Psr\Log\LoggerInterface;
 use M6Web\Bundle\LogBridgeBundle\Matcher\MatcherInterface;
 use M6Web\Bundle\LogBridgeBundle\Formatter\FormatterInterface;
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
 
 /**
  * LogRequestListener
@@ -43,7 +44,7 @@ class LogRequestListener
     /**
      * onKernelTerminate
      *
-     * @param FilterResponseEvent $event Event
+     * @param TerminateEvent $event Event
      */
     public function onKernelTerminate($event)
     {


### PR DESCRIPTION
## Description

For our project we need #74 fix, but we don't want to wait for PHP8 upgrade.
This will be pushed into a new `v6` branch (based on latest v6 tag) that will lead to a `6.1.0` version